### PR TITLE
Allow configuration of channel for ESP-NOW

### DIFF
--- a/esphome/components/now_mqtt/__init__.py
+++ b/esphome/components/now_mqtt/__init__.py
@@ -9,6 +9,7 @@ from esphome.const import (
 )
 from esphome.core import coroutine_with_priority, CORE
 
+CONF_CHANNEL = "wifi_channel"
 CONF_ON_SEND = "on_sent"
 
 now_mqtt_ns = cg.esphome_ns.namespace("now_mqtt")
@@ -20,6 +21,7 @@ Now_MQTTComponent = now_mqtt_ns.class_(
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(Now_MQTTComponent),
+    cv.Optional(CONF_CHANNEL, default=1): cv.int_range(1, 14),
     cv.Optional(CONF_ON_SEND): automation.validate_automation(
         {
             cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(ESPNowSendTrigger),
@@ -31,6 +33,7 @@ CONFIG_SCHEMA = cv.Schema({
 @coroutine_with_priority(40.0)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_wifi_channel(config[CONF_CHANNEL]))
     await cg.register_component(var, config)
 
     for conf in config.get(CONF_ON_SEND, []):

--- a/esphome/components/now_mqtt/now_mqtt.cpp
+++ b/esphome/components/now_mqtt/now_mqtt.cpp
@@ -24,6 +24,7 @@ namespace esphome
             ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
             ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
             ESP_ERROR_CHECK(esp_wifi_start());
+            ESP_ERROR_CHECK(esp_wifi_set_channel(this->wifi_channel_, WIFI_SECOND_CHAN_NONE));
 
             if (esp_now_init() != ESP_OK)
             {
@@ -33,7 +34,7 @@ namespace esphome
             }
             esp_wifi_set_protocol(WIFI_IF_STA, WIFI_PROTOCOL_LR);
             memcpy(peerInfo.peer_addr, broadcastAddress, 6);
-            peerInfo.channel = 1;
+            peerInfo.channel = this->wifi_channel_;
             peerInfo.encrypt = false;
 
             if (esp_now_add_peer(&peerInfo) != ESP_OK)

--- a/esphome/components/now_mqtt/now_mqtt.h
+++ b/esphome/components/now_mqtt/now_mqtt.h
@@ -20,7 +20,11 @@ namespace esphome
         {
         public:
             void setup() override;
+            void set_wifi_channel(uint8_t channel) { this->wifi_channel_ = channel; }
             void add_on_state_callback(std::function<void(float)> &&callback) { this->callback_.add(std::move(callback)); }
+
+        protected:
+            uint8_t wifi_channel_;
 
         private:
             CallbackManager<void(float)> callback_;

--- a/esphome/components/now_mqtt_bridge/__init__.py
+++ b/esphome/components/now_mqtt_bridge/__init__.py
@@ -6,6 +6,8 @@ from esphome.const import (
 )
 from esphome.core import coroutine_with_priority, CORE
 
+CONF_CHANNEL = "wifi_channel"
+
 now_mqtt_bridge_ns = cg.esphome_ns.namespace("now_mqtt_bridge")
 
 Now_MQTT_BridgeComponent = now_mqtt_bridge_ns.class_(
@@ -14,11 +16,14 @@ Now_MQTT_BridgeComponent = now_mqtt_bridge_ns.class_(
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(Now_MQTT_BridgeComponent),
+    cv.Optional(CONF_CHANNEL, default=1): cv.int_range(1, 14),
 })
 
 
 @coroutine_with_priority(1.0)
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
+    cg.add(var.set_wifi_channel(config[CONF_CHANNEL]))
     await cg.register_component(var, config)
 
+    cg.add_define("ESPNOW_CHANNEL", config[CONF_CHANNEL])

--- a/esphome/components/now_mqtt_bridge/now_mqtt_bridge.cpp
+++ b/esphome/components/now_mqtt_bridge/now_mqtt_bridge.cpp
@@ -202,7 +202,7 @@ namespace esphome
             ESP_ERROR_CHECK(esp_wifi_set_storage(WIFI_STORAGE_RAM));
             ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA));
             ESP_ERROR_CHECK(esp_wifi_start());
-            ESP_ERROR_CHECK(esp_wifi_set_channel(1, WIFI_SECOND_CHAN_NONE));
+            ESP_ERROR_CHECK(esp_wifi_set_channel(this->wifi_channel_, WIFI_SECOND_CHAN_NONE));
             #endif
             uint8_t broadcastAddress[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
             esp_now_peer_info_t peerInfo = {};

--- a/esphome/components/now_mqtt_bridge/now_mqtt_bridge.h
+++ b/esphome/components/now_mqtt_bridge/now_mqtt_bridge.h
@@ -31,6 +31,10 @@ namespace esphome
         public:
             void setup() override;
             float get_setup_priority() const override;
+            void set_wifi_channel(uint8_t channel) { this->wifi_channel_ = channel; }
+
+        protected:
+            uint8_t wifi_channel_;
 
         private:
             static int32_t last_rssi;


### PR DESCRIPTION
This adds an option (`wifi_channel`) to `now_mqtt` and `now_mqtt_bridge` to allow setting a channel other than 1.